### PR TITLE
Added missing line from previous edit.

### DIFF
--- a/16.04/usr.bin.remmina
+++ b/16.04/usr.bin.remmina
@@ -71,6 +71,7 @@
   /usr/share/remmina/external_tools/** rix,
   /usr/bin/gnome-terminal rix,
   /usr/bin/gnome-terminal.real rix,
+  /bin/dash rix,
   
   # Necessary for saved Remmina profiles 
   owner @{HOME}/.config/freerdp/known_hosts rw,	


### PR DESCRIPTION
You're absolutely right about the dash part. I forgot one line... @simondeziel 

Here's the logged entry without bin/dash:
> AVC apparmor="DENIED" operation="exec" profile="/usr/bin/remmina" name="/bin/dash" pid=27372 comm="remmina" requested_mask="x" denied_mask="x" fsuid=1000 ouid=0